### PR TITLE
chore: Update .gitignore to exclude backup files and retain log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 !sketchybar/**
 
 **/*log*
+**/*.bak


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude backup files with the `.bak` extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->